### PR TITLE
feat: remove adding UC to YouTube id search

### DIFF
--- a/apis/youtube/api.go
+++ b/apis/youtube/api.go
@@ -84,7 +84,7 @@ func (api *API) getChannel(searchQuery string) (*Channel, error) {
 // GetChannel returns the details of the Channel having the given id or username
 func (api *API) GetChannel(search string) (*Channel, error) {
 	// Try searching with the ID
-	channel, err := api.getChannel(fmt.Sprintf("id=UC%s", search))
+	channel, err := api.getChannel(fmt.Sprintf("id=%s", search))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR removes the forced addition of the `UC` prefix while searching a channel based on its id 

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [ ] Updated the documentation. 
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
