### PR TITLE
docs: fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Themis
 > Themis, (Greek: “Order”) in Greek religion, personification of justice, goddess of wisdom and good counsel, and the interpreter of the gods' will.
 
-Themis is a collection of REST APIs, [Band Protocol data sources](https://docs.bandchain.org/whitepaper/terminology.html#data-sources) and [Band Protocol oracle scripts](https://docs.bandchain.org/whitepaper/terminology.html#oracle-scripts) that work together in order to make it possible for [Desmos](https://desmos.network) users to connect their profile to common social network profiles owned by them.
+Themis is a collection of REST APIs, [Band Protocol data sources](https://docs.bandchain.org/introduction/how-bandchain-works#data-sources) and [Band Protocol oracle scripts](https://docs.bandchain.org/introduction/how-bandchain-works#oracle-scripts) that work together in order to make it possible for [Desmos](https://desmos.network) users to connect their profile to common social network profiles owned by them.
 
 The connection process is defined as follows: 
 1. The user signs their social network username with the private key associated with their Desmos profile. 

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Once the data has been retrieved from the proper location (eg. tweet, Gist, etc.
 
 
 ## Documentation 
-If you want to know which application we support and how everything works, please refer to the [_.docs_ folder](docs).
+If you want to know which application we support and how everything works, please refer to the [_.docs_ folder](./.docs/apis.md).


### PR DESCRIPTION
## Description
Fixing the links to Band Protocol definitions in the README.

Closes #119.

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [x] Updated the documentation. 
- [x] Re-reviewed `Files changed` in the Github PR explorer.
